### PR TITLE
Fix makefile *** missing separator issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ clean:
 	$(GOCLEAN)
 	rm -f $(BINARY_NAME)
 dep:
-    $(GOGET) github.com/aws/aws-sdk-go
-    $(GOGET) github.com/cloudflare/tableflip
-    $(GOGET) github.com/djherbis/atime
-    $(GOGET) github.com/gorilla/mux
-    $(GOGET) github.com/pkg/errors
-    $(GOGET) github.com/rcrowley/go-metrics
-    $(GOGET) github.com/spf13/viper
+	$(GOGET) github.com/aws/aws-sdk-go
+	$(GOGET) github.com/cloudflare/tableflip
+	$(GOGET) github.com/djherbis/atime
+	$(GOGET) github.com/gorilla/mux
+	$(GOGET) github.com/pkg/errors
+	$(GOGET) github.com/rcrowley/go-metrics
+	$(GOGET) github.com/spf13/viper


### PR DESCRIPTION
This PR will fix `Makefile:21: *** missing separator.  Stop` error.

Tabs should be used to indent instead of space