### PR TITLE
Added support to resize remote image: #16

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -68,7 +68,7 @@ func NewApi(ready chan<- bool) *Api {
 		Thumbnails: thumbCache,
 		Tiers:      collections.NewSyncStrSet(),
 		Etags:      etags,
-		Router:     mux.NewRouter().StrictSlash(true),
+		Router:     mux.NewRouter().StrictSlash(true).SkipClean(true),
 	}
 	go api.initCacheLoader(ready)
 	api.initCacheManager()

--- a/api/routes.go
+++ b/api/routes.go
@@ -93,7 +93,8 @@ func (api *Api) serveThumbs() http.HandlerFunc {
 				vars["resizeOp"],
 				vars["options"])
 			path := vars["path"]
-			thumbPath := resizeTier + "/" + path
+			thumbPath, _ := api.Originals.RemoteToLocalPath(path)
+			thumbPath = resizeTier + "/" + thumbPath
 			api.Tiers.Add(resizeTier)
 			thumbBuf, _ := api.Thumbnails.Get(thumbPath)
 			if thumbBuf == nil {


### PR DESCRIPTION
A path is 'remote' if net.url.Parse(path).Scheme is not empty.
TwoTier.RemoteLocalPath convert URL to local path which is then use for storage,cache and thumbnails.

Since I'm far from an expert level in golang, I'm not sure this is the right way to handle this part.
Please note this a work in progress since I think that security is not handled with this patch.